### PR TITLE
dtostrf -> sprintf for Particle Core

### DIFF
--- a/firmware/ThingSpeak.h
+++ b/firmware/ThingSpeak.h
@@ -1476,7 +1476,7 @@ private:
           //Photon doesn't have a dtostrf, but does have dtoa
           dtoa((double)value,5, valueString);
         #else
-		  dtostrf(value,1,5, valueString);
+		sprintf(valueString,"%1.5f",value);
         #endif
 		return OK_SUCCESS;
 	};


### PR DESCRIPTION
Using the library in the Particle web IDE, the example "WriteVoltage.ino" does not compile for the Core. Compiling against firmware version 0.4.9. The error message is:

```
/tmp/ccP99JT2.ltrans1.ltrans.o: In function `ThingSpeakClass::convertFloatToChar(float, char*) [clone .isra.10]':
ThingSpeak/ThingSpeak.h:1479: undefined reference to `dtostrf(double, signed char, unsigned char, char*)'
collect2: error: ld returned 1 exit status
make[1]: *** [d88e799b3df6ec17e886da138c25083b3eead3de16148e2f6066aee44e4c.elf] Error 1
make: *** [main] Error 2
```

Changing dtostrf to sprintf solves the problem.
