### PR TITLE
Added BSOM and B5SOM elifs

### DIFF
--- a/src/ThingSpeak.h
+++ b/src/ThingSpeak.h
@@ -38,6 +38,10 @@
     #elif PLATFORM_ID == 13
         #define PARTICLE_BORON
         #define PARTICLE_PHOTONELECTRON
+    #elif PLATFORM_ID == 23
+        #define PARTICLE_BSOM
+    #elif PLATFORM_ID == 25
+        #define PARTICLE_B5SOM
     #elif PLATFORM_ID == 14
         #error TCP connection are not supported on mesh nodes (Xenon), only mesh gateways (Argon, Boron)
     #else


### PR DESCRIPTION
Added the Elifs to identify the BSOM and B5SOM.
The devices are essentially Borons minus the power components and minor pin changes, thus the code should function without issue.